### PR TITLE
Allow non local requests in development and allow donors to stay logged in.

### DIFF
--- a/PolloPollo.Repository/DonorRepository.cs
+++ b/PolloPollo.Repository/DonorRepository.cs
@@ -117,19 +117,19 @@ namespace PolloPollo.Services
                        };
             return list;
         }
-        public async Task<DonorDTO> ReadAsync(string aaDonorAccount)
+        public async Task<DetailedDonorDTO> ReadAsync(string aaDonorAccount)
         {
             var donor = await _context.Donors.FindAsync(aaDonorAccount);
 
             if (donor is null) return null;
-            return new DonorDTO
+            return new DetailedDonorDTO
             {
                 AaAccount = donor.AaAccount,
-                Password = donor.Password,
                 UID = donor.UID,
                 Email = donor.Email,
                 DeviceAddress = donor.DeviceAddress,
-                WalletAddress = donor.WalletAddress
+                WalletAddress = donor.WalletAddress,
+                UserRole = "Donor"
             };
         }
 

--- a/PolloPollo.Repository/IDonorRepository.cs
+++ b/PolloPollo.Repository/IDonorRepository.cs
@@ -15,7 +15,7 @@ namespace PolloPollo.Services
         Task<(HttpStatusCode statusCode, DonorBalanceDTO balance)> GetDonorBalanceAsync(string aaDonorAccount);
         Task<(UserCreateStatus Status, string AaAccount)> CreateAsync(DonorCreateDTO dto);
         IQueryable<DonorListDTO> ReadAll();
-        Task<DonorDTO> ReadAsync(string aaDonorAccount);
+        Task<DetailedDonorDTO> ReadAsync(string aaDonorAccount);
         Task<bool> DeleteAsync(string aaDonorAccount);
         Task<HttpStatusCode> UpdateAsync(DonorUpdateDTO dto);
         Task<(UserAuthStatus status, DetailedDonorDTO DTO, string token)> AuthenticateAsync(string email, string password);

--- a/PolloPollo.Web.Tests/Controllers/ApplicationsControllerTests .cs
+++ b/PolloPollo.Web.Tests/Controllers/ApplicationsControllerTests .cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Authorization;
 using PolloPollo.Services;
 using PolloPollo.Shared.DTO;
 using System.Net;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace PolloPollo.Web.Controllers.Tests
@@ -74,7 +75,7 @@ namespace PolloPollo.Web.Controllers.Tests
             var applicationRepository = new Mock<IApplicationRepository>();
             applicationRepository.Setup(s => s.CreateAsync(It.IsAny<ApplicationCreateDTO>())).ReturnsAsync(expected);
 
-            var productRepository = new Mock<IProductRepository>();            
+            var productRepository = new Mock<IProductRepository>();
 
             var userRepository = new Mock<IUserRepository>();
             userRepository.Setup(s => s.FindAsync(It.IsAny<int>())).ReturnsAsync(expectedProducer);
@@ -82,10 +83,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var walletRepository = new Mock<IWalletRepository>();
             walletRepository.Setup(s => s.AaCreateApplicationAsync("1234", 0, false)).ReturnsAsync((true, HttpStatusCode.OK, "QWERTY"));
 
+            var env = new Mock<IWebHostEnvironment>();
             var log = new Mock<ILogger<ApplicationsController>>();
 
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
-            
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
+
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
@@ -121,8 +123,10 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var walletRepository = new Mock<IWalletRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -156,8 +160,10 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var walletRepository = new Mock<IWalletRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -197,8 +203,10 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var walletRepository = new Mock<IWalletRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -225,8 +233,10 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var walletRepository = new Mock<IWalletRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -260,8 +270,10 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var walletRepository = new Mock<IWalletRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.Get(id);
 
@@ -280,9 +292,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.Get(id);
 
@@ -303,8 +316,10 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var walletRepository = new Mock<IWalletRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetOpen(0, 0);
             var value = get.Value as ApplicationListDTO;
@@ -328,8 +343,10 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var walletRepository = new Mock<IWalletRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetOpen(0, 1);
             var value = get.Value as ApplicationListDTO;
@@ -354,8 +371,10 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var walletRepository = new Mock<IWalletRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetOpen(1, 2);
             var value = get.Value as ApplicationListDTO;
@@ -381,8 +400,10 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var walletRepository = new Mock<IWalletRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetOpen(2, 2);
             var value = get.Value as ApplicationListDTO;
@@ -404,9 +425,9 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
-
+            var env = new Mock<IWebHostEnvironment>();
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetFiltered(0, 0);
             var value = get.Value as ApplicationListDTO;
@@ -429,9 +450,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetFiltered(0, 1, "Country", "City");
             var value = get.Value as ApplicationListDTO;
@@ -455,9 +477,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetFiltered(1, 2);
             var value = get.Value as ApplicationListDTO;
@@ -482,9 +505,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetFiltered(2, 2);
             var value = get.Value as ApplicationListDTO;
@@ -506,9 +530,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetCompleted(0, 0);
             var value = get.Value as ApplicationListDTO;
@@ -531,9 +556,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetCompleted(0, 1);
             var value = get.Value as ApplicationListDTO;
@@ -557,9 +583,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetCompleted(1, 2);
             var value = get.Value as ApplicationListDTO;
@@ -584,9 +611,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetCompleted(2, 2);
             var value = get.Value as ApplicationListDTO;
@@ -625,9 +653,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetByReceiver(input);
 
@@ -669,9 +698,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetByReceiver(input, ApplicationStatusEnum.All.ToString());
 
@@ -713,9 +743,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetByReceiver(input, ApplicationStatusEnum.Unavailable.ToString());
 
@@ -753,9 +784,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetByReceiver(input, ApplicationStatusEnum.Open.ToString());
 
@@ -793,9 +825,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetByReceiver(input, ApplicationStatusEnum.Pending.ToString());
 
@@ -817,9 +850,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetByReceiver(input);
 
@@ -841,9 +875,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetByReceiver(input, "test");
 
@@ -880,9 +915,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetWithdrawableByProducer(input);
 
@@ -908,9 +944,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = await controller.GetWithdrawableByProducer(input);
 
@@ -938,9 +975,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -975,9 +1013,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1011,9 +1050,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1046,9 +1086,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1081,9 +1122,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1121,9 +1163,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1145,7 +1188,7 @@ namespace PolloPollo.Web.Controllers.Tests
             var dto = new ApplicationUpdateDTO
             {
                 ReceiverId = 1,
-                ApplicationId = 1, 
+                ApplicationId = 1,
                 Status = ApplicationStatusEnum.Pending
             };
 
@@ -1156,9 +1199,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1174,7 +1218,7 @@ namespace PolloPollo.Web.Controllers.Tests
             var dto = new ApplicationUpdateDTO
             {
                 ReceiverId = 1,
-                ApplicationId = 1, 
+                ApplicationId = 1,
                 Status = ApplicationStatusEnum.Locked
             };
 
@@ -1185,9 +1229,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             var httpContext = new DefaultHttpContext();
@@ -1217,9 +1262,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
             // Needs HttpContext to mock it.
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.LocalIpAddress = IPAddress.Parse("127.0.0.1");
@@ -1248,9 +1294,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             var httpContext = new DefaultHttpContext();
@@ -1284,9 +1331,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             var httpContext = new DefaultHttpContext();
@@ -1320,9 +1368,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             var httpContext = new DefaultHttpContext();
@@ -1356,9 +1405,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             // Needs HttpContext to mock it.
@@ -1392,9 +1442,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             // Needs HttpContext to mock it.
@@ -1430,10 +1481,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
 
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
@@ -1456,10 +1508,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
 
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
@@ -1478,10 +1531,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
 
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
@@ -1507,10 +1561,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
 
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.LocalIpAddress = IPAddress.Parse("127.0.0.1");
@@ -1543,10 +1598,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
 
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
@@ -1587,9 +1643,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1625,9 +1682,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1655,9 +1713,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1685,9 +1744,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1723,9 +1783,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1765,10 +1826,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
             walletRepository.Setup(s => s.ConfirmReceival(applicationId, null, null, null)).ReturnsAsync((true, HttpStatusCode.OK));
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1806,10 +1868,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
             walletRepository.Setup(s => s.ConfirmReceival(applicationId, null, null, null)).ReturnsAsync((false, HttpStatusCode.InternalServerError));
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1849,9 +1912,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1866,7 +1930,7 @@ namespace PolloPollo.Web.Controllers.Tests
             Assert.IsType<NotFoundResult>(result.Result);
         }
 
-        
+
 
         [Fact]
         public async Task WithdrawBytes_given_producerId_notmatching_applicationsProducerId_returns_forbidden()
@@ -1889,9 +1953,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1906,7 +1971,7 @@ namespace PolloPollo.Web.Controllers.Tests
             Assert.IsType<ForbidResult>(result.Result);
         }
 
-        
+
 
         [Fact]
         public async Task WithdrawBytes_given_producerId_invalid_role_returns_Unauthorized()
@@ -1921,9 +1986,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1951,9 +2017,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1967,7 +2034,7 @@ namespace PolloPollo.Web.Controllers.Tests
 
             Assert.IsType<ForbidResult>(result.Result);
         }
-        
+
         [Fact]
         public async Task WithdrawBytes_given_noncompleted_applicationsId_returns_UnprocessableEntity()
         {
@@ -1989,9 +2056,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -2038,10 +2106,11 @@ namespace PolloPollo.Web.Controllers.Tests
             userRepository.Setup(s => s.FindAsync(detailedProducer.UserId)).ReturnsAsync(detailedProducer);
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
             walletRepository.Setup(s => s.WithdrawBytes(applicationId, detailedProducer.Wallet, detailedProducer.Device)).ReturnsAsync((true, HttpStatusCode.OK));
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -2085,10 +2154,11 @@ namespace PolloPollo.Web.Controllers.Tests
             userRepository.Setup(s => s.FindAsync(detailedProducer.UserId)).ReturnsAsync(detailedProducer);
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
             walletRepository.Setup(s => s.WithdrawBytes(applicationId, detailedProducer.Wallet, detailedProducer.Device)).ReturnsAsync((false, HttpStatusCode.InternalServerError));
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -2123,9 +2193,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = controller.GetCountries();
 
@@ -2153,9 +2224,10 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRepository = new Mock<IUserRepository>();
 
             var walletRepository = new Mock<IWalletRepository>();
+            var env = new Mock<IWebHostEnvironment>();
 
             var log = new Mock<ILogger<ApplicationsController>>();
-            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, log.Object);
+            var controller = new ApplicationsController(applicationRepository.Object, productRepository.Object, userRepository.Object, walletRepository.Object, env.Object, log.Object);
 
             var get = controller.GetCities("DK");
 

--- a/PolloPollo.Web.Tests/Controllers/DonorsControllerTests.cs
+++ b/PolloPollo.Web.Tests/Controllers/DonorsControllerTests.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -45,9 +46,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.AuthenticateAsync(donor.Email, donor.Password)).ReturnsAsync((UserAuthStatus.WRONG_PASSWORD, null, null));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
 
             var authenticate = await controller.Authenticate(authDTO);
 
@@ -75,9 +78,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.AuthenticateAsync(donor.Email, donor.Password)).ReturnsAsync((UserAuthStatus.NO_USER, null, null));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
 
             var authenticate = await controller.Authenticate(authDTO);
 
@@ -105,9 +110,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.AuthenticateAsync(donor.Email, donor.Password)).ReturnsAsync((UserAuthStatus.MISSING_PASSWORD, null, null));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
 
             var authenticate = await controller.Authenticate(authDTO);
 
@@ -135,9 +142,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.AuthenticateAsync(donor.Email, donor.Password)).ReturnsAsync((UserAuthStatus.MISSING_EMAIL, null, null));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
 
             var authenticate = await controller.Authenticate(authDTO);
 
@@ -175,9 +184,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.AuthenticateAsync(donor.Email, donor.Password)).ReturnsAsync((UserAuthStatus.SUCCESS, detailedDonorDTO, token));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
 
             var authenticate = await controller.Authenticate(authDTO);
 
@@ -193,7 +204,7 @@ namespace PolloPollo.Web.Tests.Controllers
             Assert.Equal("test", donorAuthenticatedDTO.AaAccount);
             Assert.Equal("5", donorAuthenticatedDTO.UID);
             Assert.Equal("email@test.com", donorAuthenticatedDTO.Email);
-            Assert.Equal("123-456-789", donorAuthenticatedDTO.DeviceAddress );
+            Assert.Equal("123-456-789", donorAuthenticatedDTO.DeviceAddress);
             Assert.Equal("5", donorAuthenticatedDTO.WalletAddress);
         }
 
@@ -209,9 +220,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.CreateAccountIfNotExistsAsync(donorFromAaDepositDTO)).ReturnsAsync((true, false));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
             var put = await controller.Put(donorFromAaDepositDTO);
@@ -231,9 +244,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.CreateAccountIfNotExistsAsync(donorFromAaDepositDTO)).ReturnsAsync((false, true));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
             var put = await controller.Put(donorFromAaDepositDTO);
@@ -253,9 +268,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.CreateAccountIfNotExistsAsync(donorFromAaDepositDTO)).ReturnsAsync((false, false));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
             var put = await controller.Put(donorFromAaDepositDTO);
@@ -272,9 +289,11 @@ namespace PolloPollo.Web.Tests.Controllers
                 WalletAddress = "12345678"
             };
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(null, null, logger.Object);
+            var controller = new DonorsController(null, null, env.Object, logger.Object);
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.LocalIpAddress = System.Net.IPAddress.Parse("127.0.0.1");
             httpContext.Connection.LocalPort = 5001;
@@ -292,9 +311,11 @@ namespace PolloPollo.Web.Tests.Controllers
         {
             var applicationUnitId = "test";
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(null, null, logger.Object);
+            var controller = new DonorsController(null, null, env.Object, logger.Object);
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.LocalIpAddress = System.Net.IPAddress.Parse("127.0.0.1");
             httpContext.Connection.LocalPort = 5001;
@@ -313,11 +334,13 @@ namespace PolloPollo.Web.Tests.Controllers
             var applicationUnitId = "test";
 
             var repository = new Mock<IApplicationRepository>();
-            repository.Setup(s => s.FindByUnitAsync(applicationUnitId)).ReturnsAsync((ApplicationDTO) null);
+            repository.Setup(s => s.FindByUnitAsync(applicationUnitId)).ReturnsAsync((ApplicationDTO)null);
+
+            var env = new Mock<IWebHostEnvironment>();
 
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(null, repository.Object, logger.Object);
+            var controller = new DonorsController(null, repository.Object, env.Object, logger.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
             var put = await controller.Put(applicationUnitId);
@@ -346,9 +369,11 @@ namespace PolloPollo.Web.Tests.Controllers
             repository.Setup(s => s.FindByUnitAsync(applicationUnitId)).ReturnsAsync(application);
             repository.Setup(s => s.UpdateAsync(applicationUpdateDto)).ReturnsAsync((false, (false, null)));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(null, repository.Object, logger.Object);
+            var controller = new DonorsController(null, repository.Object, env.Object, logger.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
             var put = await controller.Put(applicationUnitId);
@@ -371,9 +396,11 @@ namespace PolloPollo.Web.Tests.Controllers
             //a created object here, will not be equal to the one actually given to UpdateAsync, we need to say on any input.
             repository.Setup(s => s.UpdateAsync(It.IsAny<ApplicationUpdateDTO>())).ReturnsAsync((true, (false, "emailerror")));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(null, repository.Object, logger.Object);
+            var controller = new DonorsController(null, repository.Object, env.Object, logger.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
             var put = await controller.Put(applicationUnitId);
@@ -396,9 +423,11 @@ namespace PolloPollo.Web.Tests.Controllers
             //a created object here, will not be equal to the one actually given to UpdateAsync, we need to say on any input.
             repository.Setup(s => s.UpdateAsync(It.IsAny<ApplicationUpdateDTO>())).ReturnsAsync((true, (false, null)));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(null, repository.Object, logger.Object);
+            var controller = new DonorsController(null, repository.Object, env.Object, logger.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
             var put = await controller.Put(applicationUnitId);
@@ -421,9 +450,11 @@ namespace PolloPollo.Web.Tests.Controllers
             //a created object here, will not be equal to the one actually given to UpdateAsync, we need to say on any input.
             repository.Setup(s => s.UpdateAsync(It.IsAny<ApplicationUpdateDTO>())).ReturnsAsync((true, (false, "emailerror")));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(null, repository.Object, logger.Object);
+            var controller = new DonorsController(null, repository.Object, env.Object, logger.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
             var put = await controller.Put(applicationUnitId);
@@ -447,9 +478,11 @@ namespace PolloPollo.Web.Tests.Controllers
             //a created object here, will not be equal to the one actually given to UpdateAsync, we need to say on any input.
             repository.Setup(s => s.UpdateAsync(It.IsAny<ApplicationUpdateDTO>())).ReturnsAsync((true, (true, null)));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(null, repository.Object, logger.Object);
+            var controller = new DonorsController(null, repository.Object, env.Object, logger.Object);
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
             var put = await controller.Put(applicationUnitId);
@@ -469,9 +502,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.UpdateAsync(donorUpdateDTO)).ReturnsAsync(HttpStatusCode.NotFound);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
 
             var put = await controller.Put(donorUpdateDTO);
 
@@ -490,9 +525,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.UpdateAsync(donorUpdateDTO)).ReturnsAsync(HttpStatusCode.OK);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
 
             var put = await controller.Put(donorUpdateDTO);
 
@@ -507,9 +544,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.GetDonorBalanceAsync(aaDonorAccount)).ReturnsAsync((HttpStatusCode.NotFound, null));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
 
             var get = await controller.GetBalance(aaDonorAccount);
 
@@ -530,9 +569,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.GetDonorBalanceAsync(aaDonorAccount)).ReturnsAsync((HttpStatusCode.OK, donorBalanceDTO));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
 
             var get = await controller.GetBalance(aaDonorAccount);
             Assert.IsType<OkObjectResult>(get);
@@ -564,9 +605,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.ReadAsync(aaDonorAccount)).ReturnsAsync(donorDTO);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
 
             var get = await controller.Get(aaDonorAccount);
             Assert.IsType<OkObjectResult>(get);
@@ -590,11 +633,13 @@ namespace PolloPollo.Web.Tests.Controllers
             var aaDonorAccount = "test";
 
             var repository = new Mock<IDonorRepository>();
-            repository.Setup(s => s.ReadAsync(aaDonorAccount)).ReturnsAsync((DonorDTO) null);
+            repository.Setup(s => s.ReadAsync(aaDonorAccount)).ReturnsAsync((DonorDTO)null);
+
+            var env = new Mock<IWebHostEnvironment>();
 
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
 
             var get = await controller.Get(aaDonorAccount);
             Assert.IsType<NotFoundResult>(get);
@@ -612,9 +657,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.CreateAsync(donorCreateDTO)).ReturnsAsync((UserCreateStatus.EMAIL_TAKEN, null));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
             var create = await controller.Post(donorCreateDTO);
 
             Assert.IsType<BadRequestObjectResult>(create.Result);
@@ -636,9 +683,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.CreateAsync(donorCreateDTO)).ReturnsAsync((UserCreateStatus.PASSWORD_TOO_SHORT, null));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
             var create = await controller.Post(donorCreateDTO);
 
             Assert.IsType<BadRequestObjectResult>(create.Result);
@@ -660,9 +709,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.CreateAsync(donorCreateDTO)).ReturnsAsync((UserCreateStatus.MISSING_PASSWORD, null));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
             var create = await controller.Post(donorCreateDTO);
 
             Assert.IsType<BadRequestObjectResult>(create.Result);
@@ -684,9 +735,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.CreateAsync(donorCreateDTO)).ReturnsAsync((UserCreateStatus.MISSING_EMAIL, null));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
             var create = await controller.Post(donorCreateDTO);
 
             Assert.IsType<BadRequestObjectResult>(create.Result);
@@ -708,7 +761,8 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.CreateAsync(donorCreateDTO)).ReturnsAsync((UserCreateStatus.SUCCESS, "ThisIsAnAAccount"));
 
-            DonorDTO dto = new DonorDTO {
+            DonorDTO dto = new DonorDTO
+            {
                 AaAccount = "ThisIsAnAAccount",
                 Password = "no",
                 UID = "5",
@@ -719,9 +773,11 @@ namespace PolloPollo.Web.Tests.Controllers
 
             repository.Setup(s => s.ReadAsync("ThisIsAnAAccount")).ReturnsAsync(dto);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
             var create = await controller.Post(donorCreateDTO);
 
             Assert.IsType<CreatedResult>(create.Result);
@@ -749,9 +805,11 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.CreateAsync(donorCreateDTO)).ReturnsAsync((UserCreateStatus.UNKNOWN_FAILURE, null));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<DonorsController>>();
 
-            var controller = new DonorsController(repository.Object, null, logger.Object);
+            var controller = new DonorsController(repository.Object, null, env.Object, logger.Object);
             var create = await controller.Post(donorCreateDTO);
 
             Assert.IsType<BadRequestObjectResult>(create.Result);

--- a/PolloPollo.Web.Tests/Controllers/DonorsControllerTests.cs
+++ b/PolloPollo.Web.Tests/Controllers/DonorsControllerTests.cs
@@ -592,14 +592,14 @@ namespace PolloPollo.Web.Tests.Controllers
         {
             var aaDonorAccount = "test";
 
-            var donorDTO = new DonorDTO
+            var donorDTO = new DetailedDonorDTO
             {
                 AaAccount = "test",
-                Password = "12345678",
                 UID = "5",
                 Email = "test@test.dk",
                 DeviceAddress = "123-456-789",
                 WalletAddress = "5",
+                UserRole = "Donor"
             };
 
             var repository = new Mock<IDonorRepository>();
@@ -615,16 +615,16 @@ namespace PolloPollo.Web.Tests.Controllers
             Assert.IsType<OkObjectResult>(get);
 
             var objectResult = get as OkObjectResult;
-            Assert.IsType<DonorDTO>(objectResult.Value);
+            Assert.IsType<DetailedDonorDTO>(objectResult.Value);
 
-            var donor = objectResult.Value as DonorDTO;
+            var donor = objectResult.Value as DetailedDonorDTO;
 
             Assert.Equal("test", donor.AaAccount);
-            Assert.Equal("12345678", donor.Password);
             Assert.Equal("5", donor.UID);
             Assert.Equal("test@test.dk", donor.Email);
             Assert.Equal("123-456-789", donor.DeviceAddress);
             Assert.Equal("5", donor.WalletAddress);
+            Assert.Equal("Donor", donor.UserRole);
         }
 
         [Fact]
@@ -633,7 +633,7 @@ namespace PolloPollo.Web.Tests.Controllers
             var aaDonorAccount = "test";
 
             var repository = new Mock<IDonorRepository>();
-            repository.Setup(s => s.ReadAsync(aaDonorAccount)).ReturnsAsync((DonorDTO)null);
+            repository.Setup(s => s.ReadAsync(aaDonorAccount)).ReturnsAsync((DetailedDonorDTO)null);
 
             var env = new Mock<IWebHostEnvironment>();
 
@@ -761,14 +761,14 @@ namespace PolloPollo.Web.Tests.Controllers
             var repository = new Mock<IDonorRepository>();
             repository.Setup(s => s.CreateAsync(donorCreateDTO)).ReturnsAsync((UserCreateStatus.SUCCESS, "ThisIsAnAAccount"));
 
-            DonorDTO dto = new DonorDTO
+            var dto = new DetailedDonorDTO
             {
                 AaAccount = "ThisIsAnAAccount",
-                Password = "no",
                 UID = "5",
                 Email = "bob@bob.com",
                 DeviceAddress = "no",
                 WalletAddress = "yes",
+                UserRole = "Donor"
             };
 
             repository.Setup(s => s.ReadAsync("ThisIsAnAAccount")).ReturnsAsync(dto);

--- a/PolloPollo.Web.Tests/Controllers/DonorsControllerTests.cs
+++ b/PolloPollo.Web.Tests/Controllers/DonorsControllerTests.cs
@@ -783,14 +783,14 @@ namespace PolloPollo.Web.Tests.Controllers
             Assert.IsType<CreatedResult>(create.Result);
 
             var result = create.Result as CreatedResult;
-            var donorDTO = result.Value as DonorDTO;
+            var donorDTO = result.Value as DetailedDonorDTO;
 
             Assert.Equal("ThisIsAnAAccount", donorDTO.AaAccount);
-            Assert.Equal("no", donorDTO.Password);
             Assert.Equal("5", donorDTO.UID);
             Assert.Equal("bob@bob.com", donorDTO.Email);
             Assert.Equal("no", donorDTO.DeviceAddress);
             Assert.Equal("yes", donorDTO.WalletAddress);
+            Assert.Equal("Donor", donorDTO.UserRole);
         }
 
         [Fact]

--- a/PolloPollo.Web.Tests/Controllers/ProductsControllerTests.cs
+++ b/PolloPollo.Web.Tests/Controllers/ProductsControllerTests.cs
@@ -14,6 +14,7 @@ using PolloPollo.Services;
 using PolloPollo.Shared.DTO;
 using PolloPollo.Web.Security;
 using System.Net;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace PolloPollo.Web.Controllers.Tests
@@ -76,9 +77,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.CreateAsync(It.IsAny<ProductCreateDTO>())).ReturnsAsync((expected, expectedMessage));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -109,9 +112,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var userRole = UserRoleEnum.Receiver.ToString();
 
             var repository = new Mock<IProductRepository>();
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -133,9 +138,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.CreateAsync(It.IsAny<ProductCreateDTO>())).ReturnsAsync((null, "Error"));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
@@ -156,9 +163,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.CreateAsync(It.IsAny<ProductCreateDTO>())).ReturnsAsync((null, "Empty DTO"));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -180,9 +189,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.CreateAsync(It.IsAny<ProductCreateDTO>())).ReturnsAsync((null, "No wallet address"));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -208,9 +219,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.ReadOpen()).Returns(dtos.Object);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.Get(0, 0);
             var value = get.Value as ProductListDTO;
@@ -228,9 +241,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.ReadOpen()).Returns(dtos.Object);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.Get(0, 1);
             var value = get.Value as ProductListDTO;
@@ -249,9 +264,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.ReadOpen()).Returns(dtos.Object);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.Get(1, 2);
             var value = get.Value as ProductListDTO;
@@ -271,9 +288,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.ReadOpen()).Returns(dtos.Object);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.Get(2, 2);
             var value = get.Value as ProductListDTO;
@@ -290,9 +309,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.ReadFiltered("ALL", "ALL")).Returns(dtos.Object);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.GetFiltered(0, 0);
             var value = get.Value as ProductListDTO;
@@ -310,9 +331,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.ReadFiltered("Country", "City")).Returns(dtos.Object);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.GetFiltered(0, 1, "Country", "City");
             var value = get.Value as ProductListDTO;
@@ -331,9 +354,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.ReadFiltered("ALL", "ALL")).Returns(dtos.Object);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.GetFiltered(1, 2);
             var value = get.Value as ProductListDTO;
@@ -351,11 +376,13 @@ namespace PolloPollo.Web.Controllers.Tests
             var dto2 = new ProductDTO { ProductId = 3 };
             var dtos = new[] { dto, dto1, dto2 }.AsQueryable().BuildMock();
             var repository = new Mock<IProductRepository>();
-            repository.Setup(s => s.ReadFiltered("ALL","ALL")).Returns(dtos.Object);
+            repository.Setup(s => s.ReadFiltered("ALL", "ALL")).Returns(dtos.Object);
+
+            var env = new Mock<IWebHostEnvironment>();
 
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.GetFiltered(2, 2);
             var value = get.Value as ProductListDTO;
@@ -381,9 +408,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.FindAsync(input)).ReturnsAsync(expected);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.Get(input);
 
@@ -398,9 +427,11 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.Get(input);
 
@@ -413,9 +444,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var input = 1;
 
             var repository = new Mock<IProductRepository>();
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.GetByProducer(input, "bad");
             var result = get.Result as BadRequestObjectResult;
@@ -443,9 +476,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.Read(input)).Returns(dtos.Object);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.GetByProducer(input, ProductStatusEnum.All.ToString());
 
@@ -460,7 +495,7 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var dto = new ProductDTO
             {
-                 Available = true
+                Available = true
             };
 
             var dto1 = new ProductDTO
@@ -472,9 +507,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.Read(input)).Returns(dtos.Object);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.GetByProducer(input, ProductStatusEnum.Available.ToString());
 
@@ -500,9 +537,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.Read(input)).Returns(dtos.Object);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.GetByProducer(input, ProductStatusEnum.Unavailable.ToString());
 
@@ -518,9 +557,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.Read(input)).Returns(dtos.Object);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = await controller.GetByProducer(input);
 
@@ -533,15 +574,17 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.GetCountAsync()).ReturnsAsync(1);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
             var get = await controller.GetCount();
 
-            Assert.Equal(1, get.Value); 
+            Assert.Equal(1, get.Value);
         }
 
         [Fact]
@@ -549,15 +592,17 @@ namespace PolloPollo.Web.Controllers.Tests
         {
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
             var get = await controller.GetCount();
 
-            Assert.Equal(0, get.Value); 
+            Assert.Equal(0, get.Value);
         }
 
         [Fact]
@@ -565,9 +610,11 @@ namespace PolloPollo.Web.Controllers.Tests
         {
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.LocalIpAddress = new IPAddress(3812831);
@@ -586,9 +633,11 @@ namespace PolloPollo.Web.Controllers.Tests
         {
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.RemoteIpAddress = new IPAddress(3812831);
@@ -604,9 +653,11 @@ namespace PolloPollo.Web.Controllers.Tests
         {
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.LocalPort = 4001;
@@ -623,9 +674,11 @@ namespace PolloPollo.Web.Controllers.Tests
         {
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.LocalIpAddress = IPAddress.Parse("127.0.0.1");
@@ -641,9 +694,11 @@ namespace PolloPollo.Web.Controllers.Tests
         {
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.LocalIpAddress = IPAddress.Parse("127.0.0.1");
@@ -662,9 +717,11 @@ namespace PolloPollo.Web.Controllers.Tests
         {
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.LocalIpAddress = IPAddress.Parse("127.0.0.1");
@@ -682,9 +739,11 @@ namespace PolloPollo.Web.Controllers.Tests
         {
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.LocalPort = 5001;
@@ -701,9 +760,11 @@ namespace PolloPollo.Web.Controllers.Tests
         {
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Connection.LocalIpAddress = IPAddress.Parse("127.0.0.1");
@@ -726,9 +787,11 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -760,9 +823,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(s => s.UpdateAsync(dto)).ReturnsAsync((true, countDTO.PendingApplications, (true, null)));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -789,9 +854,11 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -817,9 +884,11 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -848,9 +917,11 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -884,9 +955,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(r => r.UpdateImageAsync(userId, It.IsAny<IFormFile>())).ReturnsAsync(fileName);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -918,9 +991,11 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -954,9 +1029,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(r => r.UpdateImageAsync(id, It.IsAny<IFormFile>())).ReturnsAsync(default(string));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -989,9 +1066,11 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1036,9 +1115,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(r => r.UpdateImageAsync(id, It.IsAny<IFormFile>())).ThrowsAsync(new ArgumentException("Invalid image file"));
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1071,9 +1152,11 @@ namespace PolloPollo.Web.Controllers.Tests
             var repository = new Mock<IProductRepository>();
             repository.Setup(r => r.UpdateImageAsync(id, It.IsAny<IFormFile>())).ThrowsAsync(new ArgumentException());
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1108,9 +1191,11 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var repository = new Mock<IProductRepository>();
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -1139,9 +1224,11 @@ namespace PolloPollo.Web.Controllers.Tests
 
             repository.Setup(s => s.GetCountries()).Returns(queryableCountries);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = controller.GetCountries();
 
@@ -1163,9 +1250,11 @@ namespace PolloPollo.Web.Controllers.Tests
 
             repository.Setup(s => s.GetCities("DK")).Returns(queryableCities);
 
+            var env = new Mock<IWebHostEnvironment>();
+
             var logger = new Mock<ILogger<ProductsController>>();
 
-            var controller = new ProductsController(repository.Object, logger.Object);
+            var controller = new ProductsController(repository.Object, env.Object, logger.Object);
 
             var get = controller.GetCities("DK");
 

--- a/PolloPollo.Web.Tests/Controllers/UsersControllerTests.cs
+++ b/PolloPollo.Web.Tests/Controllers/UsersControllerTests.cs
@@ -839,56 +839,6 @@ namespace PolloPollo.Web.Controllers.Tests
         }
 
         [Fact]
-        public async Task Me_given_non_exsiting_donor_id_returns_correct_donor()
-        {
-            var input = "test";
-
-            var detailedDonor = new DetailedDonorDTO
-            {
-                AaAccount = input,
-                UID = "test",
-                Email = "test@test.com",
-                DeviceAddress = "test-link",
-                WalletAddress = "test-address",
-                UserRole = "Donor"
-            };
-            // Needs HttpContext to mock it.
-            controller.ControllerContext.HttpContext = new DefaultHttpContext();
-
-            //Create ClaimIdentity
-            var claims = new List<Claim>()
-            {
-                new Claim(ClaimTypes.NameIdentifier, input),
-            };
-            var identity = new ClaimsIdentity(claims);
-
-            donorrepository.Setup(s => s.ReadAsync(input)).ReturnsAsync(detailedDonor);
-
-            //Mock claim to make the HttpContext contain one.
-            var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
-            claimsPrincipalMock.Setup(m => m.HasClaim(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(true);
-
-            claimsPrincipalMock.Setup(m => m.Claims).Returns(claims);
-            //Update the HttpContext to use mocked claim
-            controller.ControllerContext.HttpContext.User = claimsPrincipalMock.Object;
-
-            var get = await controller.Me();
-
-            Assert.IsType<OkObjectResult>(get);
-
-            var objectResult = get as OkObjectResult;
-            var donor = objectResult.Value as DetailedDonorDTO;
-
-            Assert.Equal(input, donor.AaAccount);
-            Assert.Equal(detailedDonor.UID, donor.UID);
-            Assert.Equal(detailedDonor.Email, donor.Email);
-            Assert.Equal(detailedDonor.WalletAddress, donor.WalletAddress);
-            Assert.Equal(detailedDonor.DeviceAddress, donor.DeviceAddress);
-            Assert.Equal("Donor", donor.UserRole);
-        }
-
-        [Fact]
         public async Task Me_given_non_existing_donor_id_returns_NotFound()
         {
             var input = "non_existing";

--- a/PolloPollo.Web.Tests/Controllers/UsersControllerTests.cs
+++ b/PolloPollo.Web.Tests/Controllers/UsersControllerTests.cs
@@ -13,12 +13,14 @@ using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
 using Xunit;
 
 namespace PolloPollo.Web.Controllers.Tests
 {
     public class UsersControllerTests
     {
+        private Mock<IWebHostEnvironment> env;
         private Mock<ILogger<UsersController>> logger;
         private Mock<IUserRepository> userrepository;
         private Mock<IDonorRepository> donorrepository;
@@ -26,10 +28,11 @@ namespace PolloPollo.Web.Controllers.Tests
 
         public UsersControllerTests()
         {
+            env = new Mock<IWebHostEnvironment>();
             logger = new Mock<ILogger<UsersController>>();
             userrepository = new Mock<IUserRepository>();
             donorrepository = new Mock<IDonorRepository>();
-            controller = new UsersController(userrepository.Object, donorrepository.Object, logger.Object);
+            controller = new UsersController(userrepository.Object, donorrepository.Object, env.Object, logger.Object);
         }
 
         private Mock<ClaimsPrincipal> MockClaimsSecurity(int id)

--- a/PolloPollo.Web.Tests/Controllers/UsersControllerTests.cs
+++ b/PolloPollo.Web.Tests/Controllers/UsersControllerTests.cs
@@ -649,11 +649,16 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var get = await controller.Me();
 
-            Assert.Equal(expected.UserId, get.Value.UserId);
-            Assert.Equal(expected.Email, get.Value.Email);
-            Assert.Equal(expected.FirstName, get.Value.FirstName);
-            Assert.Equal(expected.UserRole, get.Value.UserRole);
-            Assert.Equal(expected.Thumbnail, get.Value.Thumbnail);
+            Assert.IsType<OkObjectResult>(get);
+
+            var objectResult = get as OkObjectResult;
+            var user = objectResult.Value as DetailedUserDTO;
+
+            Assert.Equal(expected.UserId, user.UserId);
+            Assert.Equal(expected.Email, user.Email);
+            Assert.Equal(expected.FirstName, user.FirstName);
+            Assert.Equal(expected.UserRole, user.UserRole);
+            Assert.Equal(expected.Thumbnail, user.Thumbnail);
         }
 
         [Fact]
@@ -682,11 +687,16 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var get = await controller.Me();
 
-            Assert.Equal(expected.UserId, get.Value.UserId);
-            Assert.Equal(expected.Email, get.Value.Email);
-            Assert.Equal(expected.FirstName, get.Value.FirstName);
-            Assert.Equal(expected.UserRole, get.Value.UserRole);
-            Assert.Empty(get.Value.Thumbnail);
+            Assert.IsType<OkObjectResult>(get);
+
+            var objectResult = get as OkObjectResult;
+            var user = objectResult.Value as DetailedUserDTO;
+
+            Assert.Equal(expected.UserId, user.UserId);
+            Assert.Equal(expected.Email, user.Email);
+            Assert.Equal(expected.FirstName, user.FirstName);
+            Assert.Equal(expected.UserRole, user.UserRole);
+            Assert.Empty(user.Thumbnail);
         }
 
         [Fact]
@@ -714,10 +724,15 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var get = await controller.Me();
 
-            Assert.Equal(expected.UserId, get.Value.UserId);
-            Assert.Equal(expected.Email, get.Value.Email);
-            Assert.Equal(expected.UserRole, get.Value.UserRole);
-            Assert.Equal(expected.FirstName, get.Value.FirstName);
+            Assert.IsType<OkObjectResult>(get);
+
+            var objectResult = get as OkObjectResult;
+            var user = objectResult.Value as DetailedUserDTO;
+
+            Assert.Equal(expected.UserId, user.UserId);
+            Assert.Equal(expected.Email, user.Email);
+            Assert.Equal(expected.UserRole, user.UserRole);
+            Assert.Equal(expected.FirstName, user.FirstName);
         }
 
         [Fact]
@@ -744,11 +759,15 @@ namespace PolloPollo.Web.Controllers.Tests
             controller.ControllerContext.HttpContext.User = cp.Object;
 
             var get = await controller.Me();
+            Assert.IsType<OkObjectResult>(get);
 
-            Assert.Equal(expected.UserId, get.Value.UserId);
-            Assert.Equal(expected.Email, get.Value.Email);
-            Assert.Equal(expected.FirstName, get.Value.FirstName);
-            Assert.Equal(expected.UserRole, get.Value.UserRole);
+            var objectResult = get as OkObjectResult;
+            var user = objectResult.Value as DetailedUserDTO;
+
+            Assert.Equal(expected.UserId, user.UserId);
+            Assert.Equal(expected.Email, user.Email);
+            Assert.Equal(expected.FirstName, user.FirstName);
+            Assert.Equal(expected.UserRole, user.UserRole);
         }
 
         [Fact]
@@ -766,14 +785,23 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var get = await controller.Me();
 
-            Assert.IsType<NotFoundResult>(get.Result);
+            Assert.IsType<NotFoundResult>(get);
         }
 
         [Fact]
-        public async Task Me_given_wrong_id_format_existing_id_returns_BadRequest()
+        public async Task Me_given_exsiting_donor_id_returns_correct_donor()
         {
             var input = "test";
 
+            var detailedDonor = new DetailedDonorDTO
+            {
+                AaAccount = input,
+                UID = "test",
+                Email = "test@test.com",
+                DeviceAddress = "test-link",
+                WalletAddress = "test-address",
+                UserRole = "Donor"
+            };
             // Needs HttpContext to mock it.
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
 
@@ -783,6 +811,8 @@ namespace PolloPollo.Web.Controllers.Tests
                new Claim(ClaimTypes.NameIdentifier, input),
             };
             var identity = new ClaimsIdentity(claims);
+
+            donorrepository.Setup(s => s.ReadAsync(input)).ReturnsAsync(detailedDonor);
 
             //Mock claim to make the HttpContext contain one.
             var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
@@ -795,7 +825,98 @@ namespace PolloPollo.Web.Controllers.Tests
 
             var get = await controller.Me();
 
-            Assert.IsType<BadRequestResult>(get.Result);
+            Assert.IsType<OkObjectResult>(get);
+
+            var objectResult = get as OkObjectResult;
+            var donor = objectResult.Value as DetailedDonorDTO;
+
+            Assert.Equal(input, donor.AaAccount);
+            Assert.Equal(detailedDonor.UID, donor.UID);
+            Assert.Equal(detailedDonor.Email, donor.Email);
+            Assert.Equal(detailedDonor.WalletAddress, donor.WalletAddress);
+            Assert.Equal(detailedDonor.DeviceAddress, donor.DeviceAddress);
+            Assert.Equal("Donor", donor.UserRole);
+        }
+
+        [Fact]
+        public async Task Me_given_non_exsiting_donor_id_returns_correct_donor()
+        {
+            var input = "test";
+
+            var detailedDonor = new DetailedDonorDTO
+            {
+                AaAccount = input,
+                UID = "test",
+                Email = "test@test.com",
+                DeviceAddress = "test-link",
+                WalletAddress = "test-address",
+                UserRole = "Donor"
+            };
+            // Needs HttpContext to mock it.
+            controller.ControllerContext.HttpContext = new DefaultHttpContext();
+
+            //Create ClaimIdentity
+            var claims = new List<Claim>()
+            {
+                new Claim(ClaimTypes.NameIdentifier, input),
+            };
+            var identity = new ClaimsIdentity(claims);
+
+            donorrepository.Setup(s => s.ReadAsync(input)).ReturnsAsync(detailedDonor);
+
+            //Mock claim to make the HttpContext contain one.
+            var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+            claimsPrincipalMock.Setup(m => m.HasClaim(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(true);
+
+            claimsPrincipalMock.Setup(m => m.Claims).Returns(claims);
+            //Update the HttpContext to use mocked claim
+            controller.ControllerContext.HttpContext.User = claimsPrincipalMock.Object;
+
+            var get = await controller.Me();
+
+            Assert.IsType<OkObjectResult>(get);
+
+            var objectResult = get as OkObjectResult;
+            var donor = objectResult.Value as DetailedDonorDTO;
+
+            Assert.Equal(input, donor.AaAccount);
+            Assert.Equal(detailedDonor.UID, donor.UID);
+            Assert.Equal(detailedDonor.Email, donor.Email);
+            Assert.Equal(detailedDonor.WalletAddress, donor.WalletAddress);
+            Assert.Equal(detailedDonor.DeviceAddress, donor.DeviceAddress);
+            Assert.Equal("Donor", donor.UserRole);
+        }
+
+        [Fact]
+        public async Task Me_given_non_existing_donor_id_returns_NotFound()
+        {
+            var input = "non_existing";
+
+            // Needs HttpContext to mock it.
+            controller.ControllerContext.HttpContext = new DefaultHttpContext();
+
+            //Create ClaimIdentity
+            var claims = new List<Claim>()
+            {
+                new Claim(ClaimTypes.NameIdentifier, input),
+            };
+            var identity = new ClaimsIdentity(claims);
+
+            donorrepository.Setup(s => s.ReadAsync(input)).ReturnsAsync((DetailedDonorDTO) null);
+
+            //Mock claim to make the HttpContext contain one.
+            var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+            claimsPrincipalMock.Setup(m => m.HasClaim(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(true);
+
+            claimsPrincipalMock.Setup(m => m.Claims).Returns(claims);
+            //Update the HttpContext to use mocked claim
+            controller.ControllerContext.HttpContext.User = claimsPrincipalMock.Object;
+
+            var get = await controller.Me();
+
+            Assert.IsType<NotFoundResult>(get);
         }
 
         [Fact]

--- a/PolloPollo.Web/Controllers/DonorsController.cs
+++ b/PolloPollo.Web/Controllers/DonorsController.cs
@@ -163,14 +163,14 @@ namespace PolloPollo.Web.Controllers
                 return NotFound();
             }
 
-            return Ok(new DonorDTO
+            return Ok(new DetailedDonorDTO
             {
                 AaAccount = donor.AaAccount,
-                Password = donor.Password,
                 UID = donor.UID,
                 Email = donor.Email,
                 DeviceAddress = donor.DeviceAddress,
-                WalletAddress = donor.WalletAddress
+                WalletAddress = donor.WalletAddress,
+                UserRole = "Donor"
             });
         }
         // POST api/donors
@@ -187,7 +187,7 @@ namespace PolloPollo.Web.Controllers
             switch(result.Status)
             {
                 case SUCCESS:
-                    DonorDTO createdDTO = await _donorRepository.ReadAsync(result.AaAccount);
+                    var createdDTO = await _donorRepository.ReadAsync(result.AaAccount);
                     return base.Created($"{nameof(Get)}/{result.AaAccount}", createdDTO);
                 case MISSING_EMAIL:
                     return BadRequest("No email entered");

--- a/PolloPollo.Web/Controllers/DonorsController.cs
+++ b/PolloPollo.Web/Controllers/DonorsController.cs
@@ -7,6 +7,8 @@ using PolloPollo.Shared.DTO;
 using PolloPollo.Web.Security;
 using Microsoft.Extensions.Logging;
 using System.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using PolloPollo.Shared;
 using static PolloPollo.Shared.UserCreateStatus;
 
@@ -19,12 +21,14 @@ namespace PolloPollo.Web.Controllers
     {
         private readonly IDonorRepository _donorRepository;
         private readonly IApplicationRepository _applicationRepository;
+        private readonly IWebHostEnvironment _env;
         private readonly ILogger<DonorsController> _logger;
 
-        public DonorsController(IDonorRepository dRepo, IApplicationRepository aRepo, ILogger<DonorsController> logger)
+        public DonorsController(IDonorRepository dRepo, IApplicationRepository aRepo, IWebHostEnvironment env, ILogger<DonorsController> logger)
         {
             _applicationRepository = aRepo;
             _donorRepository = dRepo;
+            _env = env;
             _logger = logger;
         }
 
@@ -36,7 +40,7 @@ namespace PolloPollo.Web.Controllers
         {
             // Only allow updates from local communicaton as only the chat-bot should report
             // application creation results.
-            if (!HttpContext.Request.IsLocal())
+            if (!HttpContext.Request.IsLocal() && !_env.IsDevelopment())
             {
                 return Forbid();
             }
@@ -86,7 +90,7 @@ namespace PolloPollo.Web.Controllers
         {
             // Only allow updates from local communicaton as only the chat-bot should report
             // application creation results.
-            if (!HttpContext.Request.IsLocal())
+            if (!HttpContext.Request.IsLocal() && !_env.IsDevelopment())
             {
                 return Forbid();
             }

--- a/PolloPollo.Web/Controllers/ProductsController.cs
+++ b/PolloPollo.Web/Controllers/ProductsController.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using PolloPollo.Services;
 using PolloPollo.Shared.DTO;
 using PolloPollo.Web.Security;
@@ -21,11 +23,13 @@ namespace PolloPollo.Web.Controllers
     public class ProductsController : ControllerBase
     {
         private readonly IProductRepository _productRepository;
+        private readonly IWebHostEnvironment _env;
         private readonly ILogger<ProductsController> _logger;
 
-        public ProductsController(IProductRepository repo, ILogger<ProductsController> logger)
+        public ProductsController(IProductRepository repo, IWebHostEnvironment env, ILogger<ProductsController> logger)
         {
             _productRepository = repo;
+            _env = env;
             _logger = logger;
         }
 
@@ -108,7 +112,7 @@ namespace PolloPollo.Web.Controllers
         // GET: api/product
         [ApiConventionMethod(typeof(DefaultApiConventions),
             nameof(DefaultApiConventions.Get))]
-        [AllowAnonymous] 
+        [AllowAnonymous]
         [HttpGet("{id}")]
         public async Task<ActionResult<ProductDTO>> Get(int id)
         {
@@ -155,7 +159,7 @@ namespace PolloPollo.Web.Controllers
         [HttpGet("count")]
         public async Task<ActionResult<int>> GetCount()
         {
-            if (!HttpContext.Request.IsLocal())
+            if (!HttpContext.Request.IsLocal() && !_env.IsDevelopment())
             {
                 return Forbid();
             }

--- a/PolloPollo.Web/Controllers/UsersController.cs
+++ b/PolloPollo.Web/Controllers/UsersController.cs
@@ -132,7 +132,7 @@ namespace PolloPollo.Web.Controllers
         [ApiConventionMethod(typeof(DefaultApiConventions),
              nameof(DefaultApiConventions.Get))]
         [HttpGet("me")]
-        public async Task<ActionResult<DetailedUserDTO>> Me()
+        public async Task<IActionResult> Me()
         {
             var claimsIdentity = User.Claims as ClaimsIdentity;
 
@@ -146,10 +146,15 @@ namespace PolloPollo.Web.Controllers
                     return NotFound();
                 }
 
-                return user;
+                return Ok(user);
+            }
+            var donor = await _donorReposistory.ReadAsync(claimId);
+            if (donor == null)
+            {
+                return NotFound();
             }
 
-            return BadRequest();
+            return Ok(donor);
         }
 
         // POST api/users

--- a/PolloPollo.Web/Controllers/UsersController.cs
+++ b/PolloPollo.Web/Controllers/UsersController.cs
@@ -7,6 +7,8 @@ using System;
 using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
 using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using PolloPollo.Services;
 using PolloPollo.Shared.DTO;
 using PolloPollo.Web.Security;
@@ -23,12 +25,14 @@ namespace PolloPollo.Web.Controllers
     {
         private readonly IUserRepository _userRepository;
         private readonly IDonorRepository _donorReposistory;
+        private readonly IWebHostEnvironment _env;
         private readonly ILogger<UsersController> _logger;
 
-        public UsersController(IUserRepository urepo, IDonorRepository drepo, ILogger<UsersController> logger)
+        public UsersController(IUserRepository urepo, IDonorRepository drepo, IWebHostEnvironment env, ILogger<UsersController> logger)
         {
             _userRepository = urepo;
             _donorReposistory = drepo;
+            _env = env;
             _logger = logger;
         }
 
@@ -97,7 +101,7 @@ namespace PolloPollo.Web.Controllers
         [HttpGet("countproducer")]
         public async Task<ActionResult<int>> GetProducerCount()
         {
-            if (!HttpContext.Request.IsLocal())
+            if (!HttpContext.Request.IsLocal() && !_env.IsDevelopment())
             {
                 return Forbid();
             }
@@ -114,7 +118,7 @@ namespace PolloPollo.Web.Controllers
         public async Task<ActionResult<int>> GetReceiverCount()
         {
 
-            if (!HttpContext.Request.IsLocal())
+            if (!HttpContext.Request.IsLocal() && !_env.IsDevelopment())
             {
                 return Forbid();
             }
@@ -227,7 +231,7 @@ namespace PolloPollo.Web.Controllers
                 {
                     return new StatusCodeResult(StatusCodes.Status500InternalServerError);
                 }
-            }     
+            }
         }
 
         // PUT api/users/5
@@ -258,9 +262,9 @@ namespace PolloPollo.Web.Controllers
         [ApiExplorerSettings(IgnoreApi = true)]
         [AllowAnonymous]
         [HttpPut("wallet")]
-        public async Task<ActionResult> PutDeviceAddress([FromBody] UserPairingDTO dto) 
+        public async Task<ActionResult> PutDeviceAddress([FromBody] UserPairingDTO dto)
         {
-            if (!HttpContext.Request.IsLocal())
+            if (!HttpContext.Request.IsLocal() && !_env.IsDevelopment())
             {
                 return Forbid();
             }

--- a/PolloPollo.Web/Program.cs
+++ b/PolloPollo.Web/Program.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;

--- a/PolloPollo.Web/appsettings.Development.json
+++ b/PolloPollo.Web/appsettings.Development.json
@@ -1,9 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
-    }
-  }
-}

--- a/PolloPollo.Web/appsettings.Development.json
+++ b/PolloPollo.Web/appsettings.Development.json
@@ -1,0 +1,9 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}


### PR DESCRIPTION
- Injects the `IWebHostEnvironment` into all controllers and lets them allow non-local requests in development environments. Tests should accommodate for the change.
- Changed the `me()` method in the `UserController` to return a `DetailedDonorDTO` instead of a `DonorDTO`, to allow donors to stay logged in on refresh on the front-end. Tests should accommodate for the change.